### PR TITLE
Original Reset Func with SW0 and new SuperMini SW0 Pin

### DIFF
--- a/boards/arm/supermini/supermini.dts
+++ b/boards/arm/supermini/supermini.dts
@@ -17,7 +17,7 @@
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
-			gpios = <&gpio1 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio0 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 0";
 		};
 	};

--- a/src/main.c
+++ b/src/main.c
@@ -510,7 +510,7 @@ void timer_init(void) {
 	irq_enable(TIMER1_IRQn);
 }
 
-#if DT_NODE_HAS_PROP(DT_ALIAS(sw0), gpios) && IGNORE_RESET // Alternate button if available to use as "reset key"
+#if DT_NODE_HAS_PROP(DT_ALIAS(sw0), gpios) // Alternate button if available to use as "reset key"
 static struct gpio_callback button_cb_data;
 void button_pressed(const struct device *dev, struct gpio_callback *cb, uint32_t pins)
 {
@@ -541,7 +541,7 @@ int main(void)
 	(*dbl_reset_mem) = DFU_DBL_RESET_APP; // Skip DFU
 #endif
 
-#if DT_NODE_HAS_PROP(DT_ALIAS(sw0), gpios) && IGNORE_RESET // Alternate button if available to use as "reset key"
+#if DT_NODE_HAS_PROP(DT_ALIAS(sw0), gpios) // Alternate button if available to use as "reset key"
 	const struct gpio_dt_spec button0 = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
 	gpio_pin_configure_dt(&button0, GPIO_INPUT);
 	reset_reason |= gpio_pin_get_dt(&button0);


### PR DESCRIPTION
Returns Reset to Original Function when SW0 is used and define is true.
New pin defined for SW0 on SuperMini (P01.06 had issue) in the Device Tree and allows easy soldering of SMD push button above the 2 pins. 

Meow!